### PR TITLE
Bugfix: Sanitize NULL trkpttime values in trackpoints table

### DIFF
--- a/omexport.py
+++ b/omexport.py
@@ -169,7 +169,7 @@ class OmExport:
                     gpxpy.gpx.GPXTrackPoint(
                         point_row['trkptlat'], point_row['trkptlon'],
                         elevation=point_row['trkptalt'],
-                        time=datetime.datetime.fromtimestamp(point_row['trkpttime'] / 1000.0)))
+                        time=datetime.datetime.fromtimestamp((point_row['trkpttime'] or 0) / 1000.0)))
 
         points.close()
         segments.close()


### PR DESCRIPTION
The 'trackpoints' table sometimes may contain NULL as values of the 'trkpttime' field, so the program will produce an exception when converting to a datetime.

This PR contains a simple bugfix that avoid that exception by converting 'None' values to 0.0. 

